### PR TITLE
fix incorrect links

### DIFF
--- a/src/components/departments/section.astro
+++ b/src/components/departments/section.astro
@@ -40,7 +40,7 @@ const t = getTranslations(lang);
 
 			{
 				withCTA ? (
-					<CTAButton href={`${lang}/about#departments`}>
+					<CTAButton href={`/${lang}/about#departments`}>
 						{t("index.departments.cta")}
 					</CTAButton>
 				) : null

--- a/src/pages/[lang]/_index/_02/section.astro
+++ b/src/pages/[lang]/_index/_02/section.astro
@@ -35,7 +35,7 @@ const t = getTranslations(lang);
 					{t("index.about-us.description")}
 				</Text.P>
 
-				<CTAButton href={`${lang}/projects`}>{t("index.about-us.cta-button")}</CTAButton>
+				<CTAButton href={`/${lang}/projects`}>{t("index.about-us.cta-button")}</CTAButton>
 			</Flex>
 
 			<!-- <Grid cols={2} rows={2} stretch="width" className="gap-6 lg:gap-8">

--- a/src/pages/[lang]/_index/_03/section.astro
+++ b/src/pages/[lang]/_index/_03/section.astro
@@ -75,16 +75,9 @@ const t = getTranslations(lang);
 				>
 					{t("index.section-3.text")}
 				</Text.P>
-				<Button
-					variant="alternative"
-					as={Link.Nav}
-					href={`${lang}/about`}
-					fullWidth
-					className="group scale-95 rounded-xl transition-transform hover:scale-100"
-				>
+				<CTAButton href={`/${lang}/about`} className="w-full">
 					{t("index.section-3.cta-button")}
-					<ArrowRight className="transition-transform group-hover:translate-x-2" />
-				</Button>
+				</CTAButton>
 			</Card.Root>
 		</Grid>
 	</VStack>


### PR DESCRIPTION
The links to `/projects` and `/about` were wrongly formatted, and the bug didn't occur in development.